### PR TITLE
Fix

### DIFF
--- a/sphere/views/FadeTransition.lua
+++ b/sphere/views/FadeTransition.lua
@@ -12,9 +12,6 @@ FadeTransition.phase = 0
 
 ---@param callback function?
 function FadeTransition:transitIn(callback)
-	if self.transiting then
-		return
-	end
 	self.callback = callback
 	self.transiting = true
 	self.phase = 1


### PR DESCRIPTION
When there is a transition from one screen to another, there is no need to lock FadeTransition, we already do this in GameView:setView. It fixes an annoying bug when the screen transition animation is playing and you press the button to change screens, which softlocks the game.