### PR TITLE
New and better score systems

### DIFF
--- a/sphere/controllers/GameplayController.lua
+++ b/sphere/controllers/GameplayController.lua
@@ -172,7 +172,7 @@ end
 function GameplayController:getImporterSettings()
 	local config = self.configModel.configs.settings
 	return {
-		midiConstantVolume = config.audio.midi.constantVolume
+		midiConstantVolume = config.audio.midi.constantVolume,
 	}
 end
 
@@ -212,12 +212,8 @@ function GameplayController:discordPlay()
 	local timeEngine = rhythmModel.timeEngine
 	self.discordModel:setPresence({
 		state = "Playing",
-		details = ("%s - %s [%s]"):format(
-			chartview.artist,
-			chartview.title,
-			chartview.name
-		),
-		endTimestamp = math.floor(os.time() + (length - timeEngine.currentTime) / timeEngine.baseTimeRate)
+		details = ("%s - %s [%s]"):format(chartview.artist, chartview.title, chartview.name),
+		endTimestamp = math.floor(os.time() + (length - timeEngine.currentTime) / timeEngine.baseTimeRate),
 	})
 end
 
@@ -225,11 +221,7 @@ function GameplayController:discordPause()
 	local chartview = self.selectModel.chartview
 	self.discordModel:setPresence({
 		state = "Playing (paused)",
-		details = ("%s - %s [%s]"):format(
-			chartview.artist,
-			chartview.title,
-			chartview.name
-		)
+		details = ("%s - %s [%s]"):format(chartview.artist, chartview.title, chartview.name),
 	})
 end
 
@@ -306,13 +298,10 @@ function GameplayController:saveScore()
 
 	local chartview = self.selectModel.chartview
 
-	local replayHash = self.replayModel:saveReplay(
-		self.playContext.chartdiff,
-		playContext
-	)
+	local replayHash = self.replayModel:saveReplay(self.playContext.chartdiff, playContext)
 
 	local chartdiff = self.cacheModel.chartdiffsRepo:createUpdateChartdiff(self.playContext.chartdiff)
-	local judge = scoreSystem.soundsphere.judges["Soundsphere"]
+	local judge = scoreSystem.soundsphere.judges["soundsphere"]
 	local score = {
 		hash = chartdiff.hash,
 		index = chartdiff.index,

--- a/sphere/models/NoteSkinModel/PlayfieldVsrg.lua
+++ b/sphere/models/NoteSkinModel/PlayfieldVsrg.lua
@@ -281,10 +281,7 @@ function PlayfieldVsrg:addJudgement(object)
 		judgements[judgement[1]] = config
 		self:add(config)
 	end
-	local key = ("game.rhythmModel.scoreEngine.scoreSystem.%s.judges.%s"):format(
-		object.score_system,
-		object.judge
-	)
+	local key = ("game.rhythmModel.scoreEngine.scoreSystem.judgements.%s"):format(object.judge)
 	return self:add(JudgementView({
 		key = key,
 		judgements = judgements,

--- a/sphere/models/RhythmModel/LogicEngine/LongLogicalNote.lua
+++ b/sphere/models/RhythmModel/LogicEngine/LongLogicalNote.lua
@@ -182,8 +182,8 @@ function LongLogicalNote:switchState(newState, reachableNote)
 		deltaTime = self:getLastTimeFromConfig(timings.LongNoteEnd)
 	end
 
-	scoreEvent.noteIndex = self.index -- required for osu LN's to track their state
-	scoreEvent.inputIndex = self.startNoteData.inputIndex -- same for this
+	scoreEvent.noteIndex = self.index
+	scoreEvent.noteIndexType = self.index .. self.input -- required for osu!legacy LN's to track their state
 	scoreEvent.currentTime = currentTime
 	scoreEvent.deltaTime = deltaTime
 	scoreEvent.timeRate = timeRate

--- a/sphere/models/RhythmModel/LogicEngine/LongLogicalNote.lua
+++ b/sphere/models/RhythmModel/LogicEngine/LongLogicalNote.lua
@@ -4,7 +4,6 @@ local LogicalNote = require("sphere.models.RhythmModel.LogicEngine.LogicalNote")
 ---@operator call: sphere.LongLogicalNote
 local LongLogicalNote = LogicalNote + {}
 
-
 ---@param noteData ncdk.NoteData
 ---@param isPlayable boolean?
 ---@param isScorable boolean?
@@ -183,7 +182,8 @@ function LongLogicalNote:switchState(newState, reachableNote)
 		deltaTime = self:getLastTimeFromConfig(timings.LongNoteEnd)
 	end
 
-	scoreEvent.noteIndex = self.index
+	scoreEvent.noteIndex = self.index -- required for osu LN's to track their state
+	scoreEvent.inputIndex = self.startNoteData.inputIndex -- same for this
 	scoreEvent.currentTime = currentTime
 	scoreEvent.deltaTime = deltaTime
 	scoreEvent.timeRate = timeRate

--- a/sphere/models/RhythmModel/LogicEngine/NoteHandler.lua
+++ b/sphere/models/RhythmModel/LogicEngine/NoteHandler.lua
@@ -24,6 +24,7 @@ function NoteHandler:load()
 		if note then
 			hnote.note = note
 			note.logicEngine = logicEngine
+			note.input = hnote.input
 			table.insert(notes, hnote)
 			logicEngine.sharedLogicalNotes[noteData] = note
 		end

--- a/sphere/models/RhythmModel/ScoreEngine/EtternaScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/EtternaScoring.lua
@@ -1,7 +1,8 @@
 --- SOURCE: https://github.com/etternagame/etterna
 --- SOURCE: https://github.com/etternagame/etterna/blob/master/Themes/_fallback/Scripts/10%20Scores.lua
 
-local class = require("class")
+local BaseJudge = require("sphere.models.RhythmModel.ScoreEngine.Judge")
+
 local erfunc = require("libchart.erfunc")
 local ScoreSystem = require("sphere.models.RhythmModel.ScoreEngine.ScoreSystem")
 
@@ -12,201 +13,190 @@ local EtternaScoring = ScoreSystem + {}
 EtternaScoring.name = "etterna"
 EtternaScoring.metadata = {
 	name = "Etterna J%d",
-	range = {4, 9}
+	range = { 4, 9 },
 }
-
-local hitWindow = 0.18
 
 local judgeTimingWindows = {
-    {33.75, 67.5, 135, 202.5, 270},
-	{29.925, 59.85, 119.7, 179.55, 239.4},
-    {26.1, 52.2, 104.4, 156.6, 208.8},
-	{22.5, 45, 90, 135, 180},
-    {18.9, 37.8, 75.6, 113.4, 180},
-	{14.85, 29.7, 59.4, 89.1, 180},
-    {11.25, 22.5, 45, 67.5, 180},
-	{7.425, 14.85, 29.7, 44.55, 180},
-    {4.5, 9, 18, 27, 180}
+	{ 33.75,  67.5,  135,   202.5,  270 },
+	{ 29.925, 59.85, 119.7, 179.55, 239.4 },
+	{ 26.1,   52.2,  104.4, 156.6,  208.8 },
+	{ 22.5,   45,    90,    135,    180 },
+	{ 18.9,   37.8,  75.6,  113.4,  180 },
+	{ 14.85,  29.7,  59.4,  89.1,   180 },
+	{ 11.25,  22.5,  45,    67.5,   180 },
+	{ 7.425,  14.85, 29.7,  44.55,  180 },
+	{ 4.5,    9,     18,    27,     180 },
 }
 
-local judgeDifficulty = {0, 0, 0, 1.00, 0.84, 0.66, 0.50, 0.33, 0.20}
+local judgeDifficulty = { 0, 0, 0, 1.00, 0.84, 0.66, 0.50, 0.33, 0.20 }
 
-local Judge = class()
+---@class sphere.EtternaJudge: sphere.Judge
+---@operator call: sphere.EtternaJudge
+local Judge = BaseJudge + {}
 
-local orderedCounters = {"marvelous", "perfect", "great", "bad", "boo"}
+Judge.orderedCounters = { "marvelous", "perfect", "great", "bad", "boo" }
 
 ---@param j number
 function Judge:new(j)
-    self.difficulty = judgeDifficulty[j]
-    self.accuracy = 0
+	self.scoreSystemName = EtternaScoring.name
+	self.difficulty = judgeDifficulty[j]
 
-    self.maxPoints = 2
-    self.maxBooWeight = 180.0 * self.difficulty
-    self.missWeight = -5.5
-    self.jPow = 0.75
-    self.ridic = 5 * self.difficulty
+	self.maxPoints = 2
+	self.maxBooWeight = 180.0 * self.difficulty
+	self.missWeight = -5.5
+	self.jPow = 0.75
+	self.ridic = 5 * self.difficulty
 
-    self.points = 0
-    self.notes = 0
+	self.points = 0
 
-    local w = judgeTimingWindows[j]
-    self.windows = {
-        marvelous = w[1],
-        perfect = w[2],
-        great = w[3],
-        bad = w[4],
-        boo = w[5]
-    }
+	local w = judgeTimingWindows[j]
+	self.windows = {
+		marvelous = w[1],
+		perfect = w[2],
+		great = w[3],
+		bad = w[4],
+		boo = w[5],
+	}
 
-    self.counters = {
-        marvelous = 0,
-        perfect = 0,
-        great = 0,
-        bad = 0,
-        boo = 0,
-        miss = 0
-    }
+	self.counters = {
+		marvelous = 0,
+		perfect = 0,
+		great = 0,
+		bad = 0,
+		boo = 0,
+		miss = 0,
+	}
+
+	self.earlyHitWindow = -0.18
+	self.lateHitWindow = 0.18
+	self.earlyMissWindow = -0.18
+	self.lateMissWindow = 0.18
+	self.windowReleaseMultiplier = 1
 end
 
 ---@param x number
 ---@return number
 local function pointsMultiplier(x)
-    local sign = 1
+	local sign = 1
 
-    if x < 0 then
+	if x < 0 then
 		sign = -1
 	end
 
-    x = math.abs(x)
+	x = math.abs(x)
 	local y = erfunc.erf(x)
 
-    return sign * y
+	return sign * y
 end
 
 ---@param deltaTime number
 ---@return number
 function Judge:getPoints(deltaTime)
-    if deltaTime <= self.ridic then return self.maxPoints end
+	if deltaTime <= self.ridic then
+		return self.maxPoints
+	end
 
-    local zero = 65.0 * math.pow(self.difficulty, self.jPow)
-    local dev = 22.7 * math.pow(self.difficulty, self.jPow)
+	local zero = 65.0 * math.pow(self.difficulty, self.jPow)
+	local dev = 22.7 * math.pow(self.difficulty, self.jPow)
 
-    if deltaTime <= zero then
-        return self.maxPoints * pointsMultiplier((zero - deltaTime) / dev)
-    end
+	if deltaTime <= zero then
+		return self.maxPoints * pointsMultiplier((zero - deltaTime) / dev)
+	end
 
-    if deltaTime <= self.maxBooWeight then
-        return (deltaTime - zero) * self.missWeight / (self.maxBooWeight - zero)
-    end
+	if deltaTime <= self.maxBooWeight then
+		return (deltaTime - zero) * self.missWeight / (self.maxBooWeight - zero)
+	end
 
-    return self.missWeight
+	return self.missWeight
 end
 
----@param deltaTime number
-function Judge:hit(deltaTime)
-    if deltaTime > hitWindow then
-        self:miss()
-        return
-    end
+---@param event table
+function Judge:hit(event)
+	local delta_time = event.deltaTime
 
-    self.notes = self.notes + 1
+	if delta_time > self.lateHitWindow then
+		self:addCounter("miss", event.currentTime)
+		return
+	end
 
-    deltaTime = math.abs(deltaTime * 1000.0)
-    self.points = self.points + self:getPoints(deltaTime)
+	delta_time = math.abs(delta_time * 1000.0)
+	self.points = self.points + self:getPoints(delta_time)
 
-    for _, key in ipairs(orderedCounters) do
-        local window = self.windows[key]
+	for _, key in ipairs(Judge.orderedCounters) do
+		local window = self.windows[key]
 
-        if deltaTime < window then
-            self.counters[key] = self.counters[key] + 1
-            return
-        end
-    end
-end
-
-function Judge:miss()
-    self.notes = self.notes + 1
-    self.counters.miss = self.counters.miss + 1
+		if delta_time < window then
+			self:addCounter(key, event.currentTime)
+			return
+		end
+	end
 end
 
 function Judge:calculateAccuracy()
-    self.accuracy = math.max(((self.points - (self.counters.miss * 5.5)) /
-                                 (self.notes * self.maxPoints)), 0)
+	self.accuracy = math.max(((self.points - (self.counters.miss * 5.5)) / (self.notes * self.maxPoints)), 0)
 end
 
 function EtternaScoring:load()
-    self.judges = {}
+	self.judges = {}
 
-    local name = self.metadata.name
-    local range = self.metadata.range
+	local name = self.metadata.name
+	local range = self.metadata.range
 
-    for i = range[1], range[2], 1 do self.judges[name:format(i)] = Judge(i) end
+	for i = range[1], range[2], 1 do
+		self.judges[name:format(i)] = Judge(i)
+	end
 end
 
-function EtternaScoring:miss()
-    for _, judge in pairs(self.judges) do
-        judge:miss()
-        judge:calculateAccuracy()
-    end
+function EtternaScoring:miss(event)
+	for _, judge in pairs(self.judges) do
+		judge:addCounter("miss", event.currentTime)
+		judge:calculateAccuracy()
+	end
 end
 
 ---@param event table
 function EtternaScoring:hit(event)
-    for _, judge in pairs(self.judges) do
-        judge:hit(event.deltaTime)
-        judge:calculateAccuracy()
-    end
+	for _, judge in pairs(self.judges) do
+		judge:hit(event)
+		judge:calculateAccuracy()
+	end
 end
 
 function EtternaScoring:getTimings()
-    local hit = hitWindow
-    local miss = hitWindow
-
-    local windows = {hit = {-hit, hit}, miss = {-miss, miss}}
-
-    return {
-        nearest = true,
-        ShortNote = windows,
-        LongNoteStart = windows,
-        LongNoteEnd = windows
-    }
-end
-
----@return table
-function Judge:getOrderedCounterNames()
-	return orderedCounters
+	local judge = Judge(4)
+	return judge:getTimings()
 end
 
 EtternaScoring.notes = {
-    ShortNote = {
+	ShortNote = {
 		clear = {
 			passed = "hit",
 			missed = "miss",
-			clear = nil
-		}
+			clear = nil,
+		},
 	},
-    LongNote = {
-        clear = {
-            startPassedPressed = "hit",
-            startMissed = "miss",
-            startMissedPressed = nil,
-            clear = nil
-        },
-        startPassedPressed = {
-            startMissed = nil,
-            endMissed = nil,
-            endPassed = nil
-        },
-        startMissedPressed = {
-            endMissedPassed = nil,
-            startMissed = nil,
-            endMissed = nil
-        },
-        startMissed = {
+	LongNote = {
+		clear = {
+			startPassedPressed = "hit",
+			startMissed = "miss",
 			startMissedPressed = nil,
-			endMissed = nil
-		}
-    }
+			clear = nil,
+		},
+		startPassedPressed = {
+			startMissed = nil,
+			endMissed = nil,
+			endPassed = nil,
+		},
+		startMissedPressed = {
+			endMissedPassed = nil,
+			startMissed = nil,
+			endMissed = nil,
+		},
+		startMissed = {
+			startMissedPressed = nil,
+			endMissed = nil,
+		},
+	},
 }
 
 return EtternaScoring

--- a/sphere/models/RhythmModel/ScoreEngine/EtternaScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/EtternaScoring.lua
@@ -17,15 +17,15 @@ EtternaScoring.metadata = {
 }
 
 local judgeTimingWindows = {
-	{ 33.75,  67.5,  135,   202.5,  270 },
+	{ 33.75, 67.5, 135, 202.5, 270 },
 	{ 29.925, 59.85, 119.7, 179.55, 239.4 },
-	{ 26.1,   52.2,  104.4, 156.6,  208.8 },
-	{ 22.5,   45,    90,    135,    180 },
-	{ 18.9,   37.8,  75.6,  113.4,  180 },
-	{ 14.85,  29.7,  59.4,  89.1,   180 },
-	{ 11.25,  22.5,  45,    67.5,   180 },
-	{ 7.425,  14.85, 29.7,  44.55,  180 },
-	{ 4.5,    9,     18,    27,     180 },
+	{ 26.1, 52.2, 104.4, 156.6, 208.8 },
+	{ 22.5, 45, 90, 135, 180 },
+	{ 18.9, 37.8, 75.6, 113.4, 180 },
+	{ 14.85, 29.7, 59.4, 89.1, 180 },
+	{ 11.25, 22.5, 45, 67.5, 180 },
+	{ 7.425, 14.85, 29.7, 44.55, 180 },
+	{ 4.5, 9, 18, 27, 180 },
 }
 
 local judgeDifficulty = { 0, 0, 0, 1.00, 0.84, 0.66, 0.50, 0.33, 0.20 }
@@ -114,7 +114,7 @@ end
 function Judge:hit(event)
 	local delta_time = event.deltaTime
 
-	if delta_time > self.lateHitWindow then
+	if delta_time < self.earlyHitWindow or delta_time > self.lateHitWindow then
 		self:addCounter("miss", event.currentTime)
 		return
 	end

--- a/sphere/models/RhythmModel/ScoreEngine/EtternaScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/EtternaScoring.lua
@@ -122,14 +122,8 @@ function Judge:hit(event)
 	delta_time = math.abs(delta_time * 1000.0)
 	self.points = self.points + self:getPoints(delta_time)
 
-	for _, key in ipairs(Judge.orderedCounters) do
-		local window = self.windows[key]
-
-		if delta_time < window then
-			self:addCounter(key, event.currentTime)
-			return
-		end
-	end
+	local counter_name = self:getCounter(delta_time, self.windows) or "miss"
+	self:addCounter(counter_name, event.currentTime)
 end
 
 function Judge:calculateAccuracy()

--- a/sphere/models/RhythmModel/ScoreEngine/Judge.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/Judge.lua
@@ -1,0 +1,60 @@
+local class = require("class")
+
+---@class sphere.Judge
+---@operator call: sphere.Judge
+local Judge = class()
+
+Judge.scoreSystemName = ""
+
+Judge.accuracy = 1
+Judge.notes = 0
+
+---@type string?
+Judge.lastCounter = nil
+Judge.lastUpdateTime = 0
+
+Judge.orderedCounters = {}
+Judge.weights = {}
+Judge.windows = {}
+Judge.counters = {}
+
+Judge.earlyHitWindow = -120
+Judge.lateHitWindow = 120
+Judge.earlyMissWindow = 160
+Judge.lateMissWindow = 160
+Judge.windowReleaseMultiplier = 1.5
+
+function Judge:calculateAccuracy() end
+
+---@param key string
+---@param currentTime number
+function Judge:addCounter(key, currentTime)
+	self.notes = self.notes + 1
+	self.counters[key] = self.counters[key] + 1
+	self.lastCounter = key
+	self.lastUpdateTime = currentTime
+end
+
+---@param event table
+function Judge:processEvent(event) end
+
+---@return table
+function Judge:getTimings()
+	local early_hit = self.earlyHitWindow
+	local late_hit = self.lateHitWindow
+	local early_miss = self.earlyMissWindow
+	local late_miss = self.lateMissWindow
+	local release_multi = self.windowReleaseMultiplier
+
+	return {
+		nearest = true,
+		ShortNote = { hit = { early_hit, late_hit }, miss = { early_miss, late_miss } },
+		LongNoteStart = { hit = { early_hit, late_hit }, miss = { early_miss, late_miss } },
+		LongNoteEnd = {
+			hit = { early_hit * release_multi, late_hit * release_multi },
+			miss = { early_miss * release_multi, late_miss * release_multi },
+		},
+	}
+end
+
+return Judge

--- a/sphere/models/RhythmModel/ScoreEngine/Judge.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/Judge.lua
@@ -11,7 +11,7 @@ Judge.notes = 0
 
 ---@type string?
 Judge.lastCounter = nil
-Judge.lastUpdateTime = 0
+Judge.lastUpdateTime = 0 -- useful for skins elements and animations
 
 Judge.orderedCounters = {}
 Judge.weights = {}
@@ -33,6 +33,25 @@ function Judge:addCounter(key, currentTime)
 	self.lastUpdateTime = currentTime
 end
 
+function Judge:addMiss(event)
+	self:addCounter("miss", event.currentTime)
+end
+
+---@param delta_time number
+---@param windows table
+---@return string?
+function Judge:getCounter(delta_time, windows)
+	delta_time = math.abs(delta_time)
+
+	for _, key in ipairs(self.orderedCounters) do
+		local window = windows[key]
+
+		if delta_time < window then
+			return key
+		end
+	end
+end
+
 ---@param event table
 function Judge:processEvent(event)
 	local is_release = event.newState == "endPassed" or event.newState == "endMissedPassed"
@@ -45,16 +64,8 @@ function Judge:processEvent(event)
 		return
 	end
 
-	delta_time = math.abs(delta_time)
-
-	for _, key in ipairs(self.orderedCounters) do
-		local window = self.windows[key]
-
-		if delta_time < window then
-			self:addCounter(key, event.currentTime)
-			return
-		end
-	end
+	local counter = self:getCounter(delta_time, self.windows) or "miss"
+	self:addCounter(counter, event.currentTime)
 end
 
 function Judge:calculateAccuracy()

--- a/sphere/models/RhythmModel/ScoreEngine/Judge.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/Judge.lua
@@ -6,6 +6,7 @@ local Judge = class()
 
 Judge.scoreSystemName = ""
 
+---@type number
 Judge.accuracy = 1
 Judge.notes = 0
 

--- a/sphere/models/RhythmModel/ScoreEngine/JudgementScoreSystem.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/JudgementScoreSystem.lua
@@ -19,11 +19,11 @@ function JudgementScoreSystem:load()
 	for _, judge in ipairs(_j.judgementSelectors) do
 		local name = judge[1]
 		self.judges[name] = {}
-		table.insert(self.judgementList, {name = name})
+		table.insert(self.judgementList, { name = name })
 	end
 
 	for name, judge in pairs(_j.judgementLists) do
-		self.judges[name].orderedCounterNames = judge
+		self.judges[name].orderedCounters = judge
 	end
 
 	for name, judgements in pairs(_j.judgements) do
@@ -46,9 +46,6 @@ function JudgementScoreSystem:load()
 		judge.accuracy = 0
 		judge.notes = 0
 		judge.accuracyFunc = judgements.accuracy
-		judge.getOrderedCounterNames = function ()
-			return judge.orderedCounterNames
-		end
 	end
 end
 

--- a/sphere/models/RhythmModel/ScoreEngine/JudgementScoreSystem.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/JudgementScoreSystem.lua
@@ -41,6 +41,7 @@ function JudgementScoreSystem:load()
 		end
 
 		local judge = self.judges[name]
+		judge.scoreSystemName = JudgementScoreSystem.name
 		judge.counters = counters
 		judge.windows = judgements
 		judge.accuracy = 0

--- a/sphere/models/RhythmModel/ScoreEngine/LunaticRaveScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/LunaticRaveScoring.lua
@@ -128,6 +128,13 @@ function LunaticRaveScoring:mash(event)
 	end
 end
 
+---@return table
+function LunaticRaveScoring:getTimings()
+	local timings = Judge(windows["Easy"]):getTimings()
+	timings.nearest = false
+	return timings
+end
+
 LunaticRaveScoring.notes = {
 	ShortNote = {
 		clear = {

--- a/sphere/models/RhythmModel/ScoreEngine/LunaticRaveScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/LunaticRaveScoring.lua
@@ -1,0 +1,163 @@
+local BaseJudge = require("sphere.models.RhythmModel.ScoreEngine.Judge")
+
+local ScoreSystem = require("sphere.models.RhythmModel.ScoreEngine.ScoreSystem")
+
+---@class sphere.LunaticRaveScoring: sphere.ScoreSystem
+---@operator call: sphere.LunaticRaveScoring
+local LunaticRaveScoring = ScoreSystem + {}
+
+LunaticRaveScoring.name = "lr2"
+LunaticRaveScoring.metadata = {
+	name = "LR2 %s",
+	range = { 0, 3 },
+	rangeValueAlias = {
+		[0] = "Easy",
+		[1] = "Normal",
+		[2] = "Hard",
+		[3] = "Very hard",
+	},
+}
+
+---@class sphere.LunaticRaveJudge: sphere.Judge
+---@operator call: sphere.LunaticRaveJudge
+local Judge = BaseJudge + {}
+
+Judge.orderedCounters = { "pgreat", "great", "good", "bad" }
+
+---@param windows table
+function Judge:new(windows)
+	self.scoreSystemName = LunaticRaveScoring.name
+
+	self.weights = {
+		pgreat = 2,
+		great = 1,
+		good = 0,
+		bad = 0,
+	}
+
+	self.windows = windows
+
+	self.counters = {
+		pgreat = 0,
+		great = 0,
+		good = 0,
+		bad = 0,
+		miss = 0,
+	}
+
+	self.earlyHitWindow = -self.windows.bad
+	self.lateHitWindow = self.windows.bad
+	self.earlyMissWindow = -self.windows.bad
+	self.lateMissWindow = self.windows.bad
+
+	self.windowReleaseMultiplier = 1
+end
+
+local windows = {
+	Easy = {
+		pgreat = 0.021,
+		great = 0.060,
+		good = 0.120,
+		bad = 0.200,
+	},
+	Normal = {
+		pgreat = 0.018,
+		great = 0.040,
+		good = 0.100,
+		bad = 0.200,
+	},
+	Hard = {
+		pgreat = 0.015,
+		great = 0.030,
+		good = 0.060,
+		bad = 0.200,
+	},
+	["Very hard"] = {
+		pgreat = 0.008,
+		great = 0.024,
+		good = 0.040,
+		bad = 0.200,
+	},
+}
+
+---@param event table
+function Judge:mash(event)
+	self.counters["miss"] = self.counters["miss"] + 1
+	self.lastCounter = "miss"
+	self.lastUpdateTime = event.currentTime
+end
+
+function Judge:calculateAccuracy()
+	-- AKA exscore
+	self.accuracy = ((self.counters.pgreat * 2) + self.counters.great) / (2 * self.notes)
+end
+
+function LunaticRaveScoring:load()
+	self.judges = {}
+
+	local range = self.metadata.range
+	local name = self.metadata.name
+
+	for rank = range[1], range[2], 1 do
+		local judge_name = self.metadata.rangeValueAlias[rank]
+		self.judges[name:format(judge_name)] = Judge(windows[judge_name])
+	end
+end
+
+---@param event table
+function LunaticRaveScoring:hit(event)
+	for _, judge in pairs(self.judges) do
+		judge:processEvent(event)
+		judge:calculateAccuracy()
+	end
+end
+
+---@param event table
+function LunaticRaveScoring:miss(event)
+	for _, judge in pairs(self.judges) do
+		judge:addCounter("miss", event.currentTime)
+		judge:calculateAccuracy()
+	end
+end
+
+---@param event table
+function LunaticRaveScoring:mash(event)
+	for _, judge in pairs(self.judges) do
+		judge:mash(event)
+		judge:calculateAccuracy()
+	end
+end
+
+LunaticRaveScoring.notes = {
+	ShortNote = {
+		clear = {
+			passed = "hit",
+			missed = "miss",
+			clear = "mash",
+		},
+	},
+	LongNote = {
+		clear = {
+			startPassedPressed = "hit",
+			startMissed = "miss",
+			startMissedPressed = nil,
+			clear = "mash",
+		},
+		startPassedPressed = {
+			startMissed = nil,
+			endMissed = nil,
+			endPassed = nil,
+		},
+		startMissedPressed = {
+			endMissedPassed = nil,
+			startMissed = nil,
+			endMissed = nil,
+		},
+		startMissed = {
+			startMissedPressed = nil,
+			endMissed = nil,
+		},
+	},
+}
+
+return LunaticRaveScoring

--- a/sphere/models/RhythmModel/ScoreEngine/LunaticRaveScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/LunaticRaveScoring.lua
@@ -1,3 +1,5 @@
+-- SOURCE: https://hitkey.nekokan.dyndns.info/diary1501.php#D150119
+
 local BaseJudge = require("sphere.models.RhythmModel.ScoreEngine.Judge")
 
 local ScoreSystem = require("sphere.models.RhythmModel.ScoreEngine.ScoreSystem")

--- a/sphere/models/RhythmModel/ScoreEngine/MiscScoreSystem.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/MiscScoreSystem.lua
@@ -21,7 +21,7 @@ function MiscScoreSystem:hit(event)
 		self.maxDeltaTime = deltaTime
 	end
 
-	local soundsphereJudge = self.container.soundsphere.judges["Soundsphere"]
+	local soundsphereJudge = self.container.soundsphere.judges["soundsphere"]
 	local earlyLate = soundsphereJudge.earlyLate
 	local counters = soundsphereJudge.counters
 	local notes = soundsphereJudge.notes

--- a/sphere/models/RhythmModel/ScoreEngine/OsuLegacyScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/OsuLegacyScoring.lua
@@ -1,3 +1,5 @@
+-- SOURCE: https://osu.ppy.sh/wiki/en/Gameplay/Judgement/osu!mania
+
 local math_util = require("math_util")
 
 local BaseJudge = require("sphere.models.RhythmModel.ScoreEngine.Judge")

--- a/sphere/models/RhythmModel/ScoreEngine/OsuLegacyScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/OsuLegacyScoring.lua
@@ -1,0 +1,269 @@
+local BaseJudge = require("sphere.models.RhythmModel.ScoreEngine.Judge")
+
+local ScoreSystem = require("sphere.models.RhythmModel.ScoreEngine.ScoreSystem")
+
+---@class sphere.OsuLegacyScoring: sphere.ScoreSystem
+---@operator call: sphere.OsuLegacyScoring
+local OsuLegacyScoring = ScoreSystem + {}
+
+OsuLegacyScoring.name = "osuLegacy"
+OsuLegacyScoring.metadata = {
+	name = "osu!legacy OD%d",
+	range = { 0, 10 },
+}
+
+---@class sphere.OsuLegacyJudge: sphere.Judge
+---@operator call: sphere.OsuLegacyJudge
+local Judge = BaseJudge + {}
+
+Judge.orderedCounters = { "perfect", "great", "good", "ok", "meh" }
+
+local counterIndex = {
+	perfect = 1,
+	great = 2,
+	good = 3,
+	ok = 4,
+	meh = 5,
+}
+
+---@param od number
+function Judge:new(od)
+	self.scoreSystemName = OsuLegacyScoring.name
+
+	self.weights = {
+		perfect = 300,
+		great = 300,
+		good = 200,
+		ok = 100,
+		meh = 50,
+		miss = 0,
+	}
+
+	local od3 = 3 * od
+
+	self.windows = {
+		perfect = 16 / 1000,
+		great = (64 - od3) / 1000,
+		good = (97 - od3) / 1000,
+		ok = (127 - od3) / 1000,
+		meh = (151 - od3) / 1000,
+		miss = (188 - od3) / 1000,
+	}
+
+	local w = self.windows
+
+	self.headWindow = {
+		perfect = w.perfect * 1.2,
+		great = w.great * 1.1,
+		good = w.good,
+		ok = w.ok,
+		meh = w.meh,
+		miss = w.miss,
+	}
+
+	self.tailWindow = {
+		perfect = w.perfect * 2.4,
+		great = w.great * 2.2,
+		good = w.good * 2,
+		ok = w.ok * 2,
+		meh = w.meh,
+		miss = w.miss,
+	}
+
+	self.downLongNotes = {}
+
+	self.counters = {
+		perfect = 0,
+		great = 0,
+		good = 0,
+		ok = 0,
+		meh = 0,
+		miss = 0,
+	}
+
+	self.earlyHitWindow = -self.windows.meh
+	self.lateHitWindow = self.windows.ok
+	self.earlyMissWindow = -self.windows.miss
+	self.lateMissWindow = self.windows.ok
+
+	self.windowReleaseMultiplier = 2.4
+end
+
+---@param self sphere.OsuLegacyJudge
+---@param delta_time number
+---@param windows table
+local function getCounter(self, delta_time, windows)
+	for _, key in ipairs(self.orderedCounters) do
+		local window = windows[key]
+
+		if delta_time < window then
+			return key
+		end
+	end
+end
+
+---@param self sphere.OsuLegacyJudge
+---@return string?
+local function getStartCounter(self, event)
+	local input = self.downLongNotes[event.inputIndex]
+
+	if input then
+		return input[event.noteIndex]
+	end
+end
+
+---@param self sphere.OsuLegacyJudge
+local function setStartCounter(self, event, counter_name)
+	local input = self.downLongNotes[event.inputIndex] or {}
+	input[event.noteIndex] = counter_name
+
+	self.downLongNotes[event.inputIndex] = input
+end
+
+---@param event table
+function Judge:processEvent(event)
+	local is_release = event.newState == "endPassed" or event.newState == "endMissedPassed"
+	local is_long_note = event.noteType == "LongNote"
+
+	local delta_time = event.deltaTime
+
+	local late_hit_window = is_release and self.lateHitWindow * self.windowReleaseMultiplier or self.lateHitWindow
+
+	if delta_time < self.earlyHitWindow or delta_time > late_hit_window then
+		self:addCounter("miss", event.currentTime)
+		return
+	end
+
+	delta_time = math.abs(delta_time)
+
+	local counter_name
+
+	if is_release then
+		local tail = getCounter(self, delta_time, self.tailWindow)
+		local start = getStartCounter(self, event)
+
+		if not start then
+			self:addCounter("meh", event.currentTime)
+			return
+		end
+
+		local tail_index = counterIndex[tail]
+		local start_index = counterIndex[start]
+
+		counter_name = self.orderedCounters[math.max(start_index, tail_index)]
+		self:addCounter(counter_name, event.currentTime)
+	elseif not is_release and is_long_note then
+		counter_name = getCounter(self, delta_time, self.headWindow)
+		setStartCounter(self, event, counter_name)
+	else
+		counter_name = getCounter(self, delta_time, self.windows)
+		self:addCounter(counter_name, event.currentTime)
+	end
+end
+
+---@param event table
+function Judge:processMiss(event)
+	if event.noteType == "ShortNote" then
+		self:addCounter("miss", event.currentTime)
+		return
+	end
+
+	local old = event.oldState
+	local new = event.newState
+
+	if old == "startMissed" and new == "endMissed" then
+		self:addCounter("miss", event.currentTime)
+		return
+	end
+
+	-- Mashing near the tail but not hitting it should give miss instead of nothing
+	if old == "startMissedPressed" and new == "endMissed" then
+		self:addCounter("miss", event.currentTime)
+		return
+	end
+
+	if old == "startPassedPressed" and new == "endMissed" then
+		local counter = getStartCounter(self, event) or "meh"
+		local counter_index = math.min(counterIndex[counter] + 2, 5)
+		self:addCounter(self.orderedCounters[counter_index], event.currentTime)
+		return
+	end
+
+	if old == "startPassedPressed" and new == "startMissed" then
+		setStartCounter(self, event, "meh")
+		return
+	end
+
+	-- Pressed out of hit window. Still counts as hit
+	if old == "clear" and new == "startMissedPressed" then
+		setStartCounter(self, event, "meh")
+		return
+	end
+
+	--- Pressing on body several times
+	if old == "startMissed" and new == "startMissedPressed" then
+		setStartCounter(self, event, "meh")
+		return
+	end
+end
+
+function OsuLegacyScoring:load()
+	self.judges = {}
+
+	local range = self.metadata.range
+	local name = self.metadata.name
+
+	for od = range[1], range[2], 1 do
+		self.judges[name:format(od)] = Judge(od)
+	end
+end
+
+---@param event table
+function OsuLegacyScoring:hit(event)
+	for _, judge in pairs(self.judges) do
+		judge:processEvent(event)
+		judge:calculateAccuracy()
+	end
+end
+
+---@param event table
+function OsuLegacyScoring:miss(event)
+	for _, judge in pairs(self.judges) do
+		judge:processMiss(event)
+		judge:calculateAccuracy()
+	end
+end
+
+OsuLegacyScoring.notes = {
+	ShortNote = {
+		clear = {
+			passed = "hit",
+			missed = "miss",
+			clear = nil,
+		},
+	},
+	LongNote = {
+		clear = {
+			startPassedPressed = "hit",
+			startMissed = "miss",
+			startMissedPressed = "miss",
+			clear = nil,
+		},
+		startPassedPressed = {
+			startMissed = "miss", -- !!! 50
+			endMissed = "miss", -- !!! - 50
+			endPassed = "hit", -- !!! - any
+		},
+		startMissedPressed = {
+			endMissedPassed = "hit", -- !!! 50
+			startMissed = nil,
+			endMissed = "miss",
+		},
+		startMissed = {
+			startMissedPressed = "miss",
+			endMissed = "miss",
+		},
+	},
+}
+
+return OsuLegacyScoring

--- a/sphere/models/RhythmModel/ScoreEngine/OsuLegacyScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/OsuLegacyScoring.lua
@@ -118,7 +118,7 @@ function Judge:new(od)
 	self.earlyMissWindow = -self.windows.miss
 	self.lateMissWindow = self.windows.ok
 
-	self.windowReleaseMultiplier = 2.4
+	self.windowReleaseMultiplier = 1
 
 	self.baseScore = 0
 	self.bonusScore = 0
@@ -279,6 +279,13 @@ function OsuLegacyScoring:load()
 	end
 
 	totalNotes = self.scoreEngine.noteChart.chartmeta.notes_count
+end
+
+function OsuLegacyScoring:getTimings(od)
+	local judge = Judge(od)
+	local timings = judge:getTimings()
+	timings.nearest = false
+	return timings
 end
 
 OsuLegacyScoring.notes = {

--- a/sphere/models/RhythmModel/ScoreEngine/OsuManiaScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/OsuManiaScoring.lua
@@ -61,41 +61,6 @@ function Judge:new(od)
 	self.windowReleaseMultiplier = 1.5
 end
 
----@param event table
-function Judge:processEvent(event)
-	local isRelease = event.newState == "endPassed" or event.newState == "endMissedPassed"
-
-	local deltaTime = event.deltaTime
-	deltaTime = isRelease and deltaTime / self.windowReleaseMultiplier or deltaTime
-
-	if deltaTime > self.lateHitWindow then
-		self:addCounter("miss", event.currentTime)
-		return
-	end
-
-	deltaTime = math.abs(deltaTime)
-
-	for _, key in ipairs(self.orderedCounters) do
-		local window = self.windows[key]
-
-		if deltaTime < window then
-			self:addCounter(key, event.currentTime)
-			return
-		end
-	end
-end
-
-function Judge:calculateAccuracy()
-	local maxScore = self.notes * self.weights.perfect
-	local score = 0
-
-	for key, count in pairs(self.counters) do
-		score = score + (self.weights[key] * count)
-	end
-
-	self.accuracy = maxScore > 0 and score / maxScore or 1
-end
-
 function OsuManiaScoring:load()
 	self.judges = {}
 

--- a/sphere/models/RhythmModel/ScoreEngine/OsuManiaScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/OsuManiaScoring.lua
@@ -40,7 +40,7 @@ function Judge:new(od)
 		great = (64 - od3) / 1000,
 		good = (97 - od3) / 1000,
 		ok = (127 - od3) / 1000,
-		meh = (157 - od3) / 1000,
+		meh = (151 - od3) / 1000,
 		miss = (188 - od3) / 1000,
 	}
 

--- a/sphere/models/RhythmModel/ScoreEngine/OsuManiaScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/OsuManiaScoring.lua
@@ -1,4 +1,4 @@
-local class = require("class")
+local BaseJudge = require("sphere.models.RhythmModel.ScoreEngine.Judge")
 
 local ScoreSystem = require("sphere.models.RhythmModel.ScoreEngine.ScoreSystem")
 
@@ -9,184 +9,157 @@ local OsuManiaScoring = ScoreSystem + {}
 OsuManiaScoring.name = "osuMania"
 OsuManiaScoring.metadata = {
 	name = "osu!mania OD%d",
-	range = {0, 10}
+	range = { 0, 10 },
 }
 
-local Judge = class()
+---@class sphere.OsuJudge: sphere.Judge
+---@operator call: sphere.OsuJudge
+local Judge = BaseJudge + {}
 
-local orderedCounters = {"perfect", "great", "good", "ok", "meh"}
+Judge.orderedCounters = { "perfect", "great", "good", "ok", "meh" }
 
 ---@param od number
 function Judge:new(od)
-    self.accuracy = 1
-    self.notes = 0
-    self.lastCounter = nil
-    self.lastUpdateTime = 0
+	self.scoreSystemName = OsuManiaScoring.name
 
-    self.weights = {
-        perfect = 305,
-        great = 300,
-        good = 200,
-        ok = 100,
-        meh = 50,
-        miss = 0
-    }
+	self.weights = {
+		perfect = 305,
+		great = 300,
+		good = 200,
+		ok = 100,
+		meh = 50,
+		miss = 0,
+	}
 
-    local od3 = 3 * od
-    self.windows = {
-        perfect = 0.016,
-        great = (64 - od3) / 1000,
-        good = (97 - od3) / 1000,
-        ok = (127 - od3) / 1000,
-        meh = (157 - od3) / 1000,
-        miss = (188 - od3) / 1000
-    }
+	local od3 = 3 * od
 
-    self.counters = {
-        perfect = 0,
-        great = 0,
-        good = 0,
-        ok = 0,
-        meh = 0,
-        miss = 0
-    }
+	local perfect_window = od < 5 and 22.4 - 0.6 * od or 24.9 - 1.1 * od
 
-    self.hitWindow = self.windows.meh
-    self.missWindow = self.windows.miss
+	self.windows = {
+		perfect = perfect_window / 1000,
+		great = (64 - od3) / 1000,
+		good = (97 - od3) / 1000,
+		ok = (127 - od3) / 1000,
+		meh = (157 - od3) / 1000,
+		miss = (188 - od3) / 1000,
+	}
 
-    self.windowReleaseMultiplier = 1.5
-end
+	self.counters = {
+		perfect = 0,
+		great = 0,
+		good = 0,
+		ok = 0,
+		meh = 0,
+		miss = 0,
+	}
 
----@param key string
----@param deltaTime number
-function Judge:addCounter(key, deltaTime)
-    self.notes = self.notes + 1
-    self.counters[key] = self.counters[key] + 1
-    self.lastCounter = key
-    self.lastUpdateTime = deltaTime
+	self.earlyHitWindow = -self.windows.meh
+	self.lateHitWindow = self.windows.ok
+	self.earlyMissWindow = -self.windows.miss
+	self.lateMissWindow = self.windows.ok
+
+	self.windowReleaseMultiplier = 1.5
 end
 
 ---@param event table
 function Judge:processEvent(event)
-    local isRelease = event.newState == "endPassed" or event.newState == "endMissedPassed"
+	local isRelease = event.newState == "endPassed" or event.newState == "endMissedPassed"
 
-    local deltaTime = event.deltaTime
-    deltaTime = isRelease and deltaTime / self.windowReleaseMultiplier or deltaTime
+	local deltaTime = event.deltaTime
+	deltaTime = isRelease and deltaTime / self.windowReleaseMultiplier or deltaTime
 
-    if deltaTime > self.hitWindow then
-        self:addCounter("miss", deltaTime)
-        return
-    end
+	if deltaTime > self.lateHitWindow then
+		self:addCounter("miss", event.currentTime)
+		return
+	end
 
-    deltaTime = math.abs(deltaTime)
+	deltaTime = math.abs(deltaTime)
 
-    for _, key in ipairs(orderedCounters) do
-        local window = self.windows[key]
+	for _, key in ipairs(self.orderedCounters) do
+		local window = self.windows[key]
 
-        if deltaTime < window then
-            self:addCounter(key, deltaTime)
-            return
-        end
-    end
+		if deltaTime < window then
+			self:addCounter(key, event.currentTime)
+			return
+		end
+	end
 end
 
 function Judge:calculateAccuracy()
-    local maxScore = self.notes * self.weights.perfect
-    local score = 0
+	local maxScore = self.notes * self.weights.perfect
+	local score = 0
 
-    for key, count in pairs(self.counters) do
-        score = score + (self.weights[key] * count)
-    end
+	for key, count in pairs(self.counters) do
+		score = score + (self.weights[key] * count)
+	end
 
-    self.accuracy = maxScore > 0 and score / maxScore or 1
-end
-
-function Judge:getTimings()
-    local hit = self.hitWindow
-    local miss = self.missWindow
-    local releaseHit = hit * self.windowReleaseMultiplier
-    local releaseMiss = miss * self.windowReleaseMultiplier
-
-    return {
-        nearest = true,
-        ShortNote = {hit = {-hit, hit}, miss = {-miss, miss}},
-        LongNoteStart = {hit = {-hit, hit}, miss = {-miss, miss}},
-        LongNoteEnd = {
-            hit = {-releaseHit, releaseHit},
-            miss = {-releaseMiss, releaseMiss}
-        }
-    }
-end
-
----@return table
-function Judge:getOrderedCounterNames()
-	return orderedCounters
+	self.accuracy = maxScore > 0 and score / maxScore or 1
 end
 
 function OsuManiaScoring:load()
-    self.judges = {}
+	self.judges = {}
 
-    local range = self.metadata.range
-    local name = self.metadata.name
+	local range = self.metadata.range
+	local name = self.metadata.name
 
-    for od = range[1], range[2], 1 do
-        self.judges[name:format(od)] = Judge(od)
-    end
+	for od = range[1], range[2], 1 do
+		self.judges[name:format(od)] = Judge(od)
+	end
 end
 
 ---@param event table
 function OsuManiaScoring:hit(event)
-    for _, judge in pairs(self.judges) do
-        judge:processEvent(event)
-        judge:calculateAccuracy()
-    end
+	for _, judge in pairs(self.judges) do
+		judge:processEvent(event)
+		judge:calculateAccuracy()
+	end
 end
 
 ---@param event table
 function OsuManiaScoring:miss(event)
-    for _, judge in pairs(self.judges) do
-        judge:addCounter("miss", event.deltaTime)
-        judge:calculateAccuracy()
-    end
+	for _, judge in pairs(self.judges) do
+		judge:addCounter("miss", event.currentTime)
+		judge:calculateAccuracy()
+	end
 end
 
 ---@param od number
 ---@return table
 function OsuManiaScoring:getTimings(od)
 	local judge = Judge(od)
-    return judge:getTimings()
+	return judge:getTimings()
 end
 
 OsuManiaScoring.notes = {
-    ShortNote = {
+	ShortNote = {
 		clear = {
 			passed = "hit",
 			missed = "miss",
-			clear = nil
-		}
+			clear = nil,
+		},
 	},
-    LongNote = {
-        clear = {
-            startPassedPressed = "hit",
-            startMissed = "miss",
-            startMissedPressed = "miss",
-            clear = nil
-        },
-        startPassedPressed = {
-            startMissed = "miss",
-            endMissed = "miss",
-            endPassed = "hit"
-        },
-        startMissedPressed = {
-            endMissedPassed = "hit",
-            startMissed = nil,
-            endMissed = nil
-        },
-        startMissed = {
+	LongNote = {
+		clear = {
+			startPassedPressed = "hit",
+			startMissed = "miss",
+			startMissedPressed = "miss",
+			clear = nil,
+		},
+		startPassedPressed = {
+			startMissed = "miss",
+			endMissed = "miss",
+			endPassed = "hit",
+		},
+		startMissedPressed = {
+			endMissedPassed = "hit",
+			startMissed = nil,
+			endMissed = nil,
+		},
+		startMissed = {
 			startMissedPressed = nil,
-			endMissed = "miss"
-		}
-    }
+			endMissed = "miss",
+		},
+	},
 }
 
 return OsuManiaScoring

--- a/sphere/models/RhythmModel/ScoreEngine/OsuManiaScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/OsuManiaScoring.lua
@@ -1,3 +1,5 @@
+-- SOURCE: https://osu.ppy.sh/wiki/en/Gameplay/Judgement/osu!mania
+
 local BaseJudge = require("sphere.models.RhythmModel.ScoreEngine.Judge")
 
 local ScoreSystem = require("sphere.models.RhythmModel.ScoreEngine.ScoreSystem")

--- a/sphere/models/RhythmModel/ScoreEngine/QuaverScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/QuaverScoring.lua
@@ -47,37 +47,6 @@ function Judge:new(windows)
 	self.windowReleaseMultiplier = 1.5
 end
 
----@param event table
-function Judge:setCounter(event)
-	local deltaTime = math.abs(event.deltaTime)
-
-	if deltaTime > self.lateHitWindow then
-		self:addCounter("miss", event.currentTime)
-		return
-	end
-
-	deltaTime = event.newState == "endPassed" and deltaTime / self.windowReleaseMultiplier or deltaTime
-
-	for _, key in ipairs(self.orderedCounters) do
-		local window = self.windows[key]
-
-		if deltaTime < window then
-			self:addCounter(key, event.currentTime)
-			return
-		end
-	end
-end
-
-function Judge:calculateAccuracy()
-	local score = 0
-
-	for key, value in pairs(self.counters) do
-		score = score + (value * self.weights[key])
-	end
-
-	self.accuracy = math.max(score / (self.notes * self.weights.marvelous), 0)
-end
-
 function Judge:getTimings()
 	local early_hit = self.earlyHitWindow
 	local late_hit = self.lateHitWindow
@@ -119,7 +88,7 @@ end
 ---@param event table
 function QuaverScoring:hit(event)
 	for _, judge in pairs(self.judges) do
-		judge:setCounter(event)
+		judge:processEvent(event)
 		judge:calculateAccuracy()
 	end
 end

--- a/sphere/models/RhythmModel/ScoreEngine/QuaverScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/QuaverScoring.lua
@@ -1,3 +1,5 @@
+-- SOURCE: https://github.com/Quaver/Quaver.API/blob/43e800efb079e9c099315c4b365490e357e2380c/Quaver.API/Maps/Processors/Scoring/ScoreProcessorKeys.cs
+
 local BaseJudge = require("sphere.models.RhythmModel.ScoreEngine.Judge")
 
 local ScoreSystem = require("sphere.models.RhythmModel.ScoreEngine.ScoreSystem")

--- a/sphere/models/RhythmModel/ScoreEngine/ScoreSystemContainer.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/ScoreSystemContainer.lua
@@ -1,4 +1,5 @@
 local class = require("class")
+local table_util = require("table_util")
 
 local ScoreSystems = {
 	require("sphere.models.RhythmModel.ScoreEngine.BaseScoreSystem"),
@@ -9,7 +10,7 @@ local ScoreSystems = {
 	require("sphere.models.RhythmModel.ScoreEngine.OsuManiaScoring"),
 	require("sphere.models.RhythmModel.ScoreEngine.QuaverScoring"),
 	require("sphere.models.RhythmModel.ScoreEngine.EtternaScoring"),
-	require("sphere.models.RhythmModel.ScoreEngine.JudgementScoreSystem")
+	require("sphere.models.RhythmModel.ScoreEngine.JudgementScoreSystem"),
 }
 
 ---@class sphere.ScoreSystemContainer
@@ -19,6 +20,7 @@ local ScoreSystemContainer = class()
 function ScoreSystemContainer:load()
 	self.scoreSystems = {}
 	self.sequence = {}
+	self.judgements = {}
 
 	local scoreSystems = self.scoreSystems
 	for _, ScoreSystem in ipairs(ScoreSystems) do
@@ -30,6 +32,12 @@ function ScoreSystemContainer:load()
 		self[ScoreSystem.name] = scoreSystem
 
 		scoreSystem:load()
+
+		local judges = scoreSystem.judges
+
+		if judges then
+			table_util.copy(judges, self.judgements)
+		end
 	end
 end
 

--- a/sphere/models/RhythmModel/ScoreEngine/ScoreSystemContainer.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/ScoreSystemContainer.lua
@@ -8,6 +8,7 @@ local ScoreSystems = {
 	require("sphere.models.RhythmModel.ScoreEngine.MiscScoreSystem"),
 	require("sphere.models.RhythmModel.ScoreEngine.SoundsphereScoring"),
 	require("sphere.models.RhythmModel.ScoreEngine.OsuManiaScoring"),
+	require("sphere.models.RhythmModel.ScoreEngine.OsuLegacyScoring"),
 	require("sphere.models.RhythmModel.ScoreEngine.QuaverScoring"),
 	require("sphere.models.RhythmModel.ScoreEngine.EtternaScoring"),
 	require("sphere.models.RhythmModel.ScoreEngine.JudgementScoreSystem"),

--- a/sphere/models/RhythmModel/ScoreEngine/ScoreSystemContainer.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/ScoreSystemContainer.lua
@@ -11,6 +11,7 @@ local ScoreSystems = {
 	require("sphere.models.RhythmModel.ScoreEngine.OsuLegacyScoring"),
 	require("sphere.models.RhythmModel.ScoreEngine.QuaverScoring"),
 	require("sphere.models.RhythmModel.ScoreEngine.EtternaScoring"),
+	require("sphere.models.RhythmModel.ScoreEngine.LunaticRaveScoring"),
 	require("sphere.models.RhythmModel.ScoreEngine.JudgementScoreSystem"),
 }
 

--- a/sphere/models/RhythmModel/ScoreEngine/timings.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/timings.lua
@@ -32,15 +32,15 @@ end
 
 timings.soundsphere = get(-0.16, -0.12, 0.12, 0.16)
 
-timings.lr2 = get(-1, -0.2, 0.2, 0.2)
-
 local osuMania = require("sphere.models.RhythmModel.ScoreEngine.OsuManiaScoring")
 local osuLegacy = require("sphere.models.RhythmModel.ScoreEngine.OsuLegacyScoring")
 local etterna = require("sphere.models.RhythmModel.ScoreEngine.EtternaScoring")
 local quaver = require("sphere.models.RhythmModel.ScoreEngine.QuaverScoring")
+local lr2 = require("sphere.models.RhythmModel.ScoreEngine.LunaticRaveScoring")
 
 timings.quaver = quaver:getTimings()
 timings.etterna = etterna:getTimings()
+timings.lr2 = lr2:getTimings()
 
 local cachedOsuMania = {}
 

--- a/sphere/models/RhythmModel/ScoreEngine/timings.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/timings.lua
@@ -11,7 +11,7 @@ local opts = {
 			out = out:gsub("\n%s+", ""):gsub(",", ", ")
 		end
 		return tag .. out
-	end
+	end,
 }
 
 local timings = {}
@@ -24,9 +24,9 @@ local timings = {}
 local function get(a, b, c, d)
 	return {
 		nearest = false,
-		ShortNote = {hit = {b, c}, miss = {a, d}},
-		LongNoteStart = {hit = {b, c}, miss = {a, d}},
-		LongNoteEnd = {hit = {b, c}, miss = {a, d}},
+		ShortNote = { hit = { b, c }, miss = { a, d } },
+		LongNoteStart = { hit = { b, c }, miss = { a, d } },
+		LongNoteEnd = { hit = { b, c }, miss = { a, d } },
 	}
 end
 
@@ -39,18 +39,7 @@ local etterna = require("sphere.models.RhythmModel.ScoreEngine.EtternaScoring")
 local quaver = require("sphere.models.RhythmModel.ScoreEngine.QuaverScoring")
 
 timings.quaver = quaver:getTimings()
-
-local cachedEtterna = {}
-
----@param judge number
----@return table
-function timings.etterna(judge)
-	if cachedEtterna[judge] then
-		return cachedEtterna[judge]
-	end
-	cachedEtterna[judge] = etterna:getTimings()
-	return cachedEtterna[judge]
-end
+timings.etterna = etterna:getTimings()
 
 local cachedOsu = {}
 
@@ -79,16 +68,16 @@ function timings.getName(t)
 	elseif s == ser(timings.lr2) then
 		return "LR2"
 	elseif s == ser(timings.quaver) then
-		return "quaver"
+		return "Quaver"
 	end
 	for od = 0, 10 do
 		if s == ser(timings.osu(od)) then
-			return "osu OD" .. od
+			return "osu!mania OD" .. od
 		end
 	end
-	for judge = 1, #etterna do
-		if s == ser(timings.etterna(judge)) then
-			return "Etterna Judgement " .. judge
+	for judge = 4, 9 do
+		if s == ser(timings.etterna) then
+			return "Etterna"
 		end
 	end
 	return "custom"

--- a/sphere/models/RhythmModel/ScoreEngine/timings.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/timings.lua
@@ -35,22 +35,35 @@ timings.soundsphere = get(-0.16, -0.12, 0.12, 0.16)
 timings.lr2 = get(-1, -0.2, 0.2, 0.2)
 
 local osuMania = require("sphere.models.RhythmModel.ScoreEngine.OsuManiaScoring")
+local osuLegacy = require("sphere.models.RhythmModel.ScoreEngine.OsuLegacyScoring")
 local etterna = require("sphere.models.RhythmModel.ScoreEngine.EtternaScoring")
 local quaver = require("sphere.models.RhythmModel.ScoreEngine.QuaverScoring")
 
 timings.quaver = quaver:getTimings()
 timings.etterna = etterna:getTimings()
 
-local cachedOsu = {}
+local cachedOsuMania = {}
 
 ---@param od number
 ---@return table
-function timings.osu(od)
-	if cachedOsu[od] then
-		return cachedOsu[od]
+function timings.osuMania(od)
+	if cachedOsuMania[od] then
+		return cachedOsuMania[od]
 	end
-	cachedOsu[od] = osuMania:getTimings(od)
-	return cachedOsu[od]
+	cachedOsuMania[od] = osuMania:getTimings(od)
+	return cachedOsuMania[od]
+end
+
+local cachedOsuLegacy = {}
+
+---@param od number
+---@return table
+function timings.osuLegacy(od)
+	if cachedOsuLegacy[od] then
+		return cachedOsuLegacy[od]
+	end
+	cachedOsuLegacy[od] = osuLegacy:getTimings(od)
+	return cachedOsuLegacy[od]
 end
 
 ---@param t table
@@ -71,8 +84,13 @@ function timings.getName(t)
 		return "Quaver"
 	end
 	for od = 0, 10 do
-		if s == ser(timings.osu(od)) then
+		if s == ser(timings.osuMania(od)) then
 			return "osu!mania OD" .. od
+		end
+	end
+	for od = 0, 10 do
+		if s == ser(timings.osuLegacy(od)) then
+			return "osu!legacy OD" .. od
 		end
 	end
 	for judge = 4, 9 do

--- a/sphere/views/GameplayView/DeltaTimeJudgementView.lua
+++ b/sphere/views/GameplayView/DeltaTimeJudgementView.lua
@@ -14,7 +14,7 @@ end
 
 function DeltaTimeJudgementView:update()
 	local scoreSystem = self.game.rhythmModel.scoreEngine.scoreSystem
-	local judge = scoreSystem.soundsphere.judges["Soundsphere"]
+	local judge = scoreSystem.soundsphere.judges["soundsphere"]
 
 	if judge.notes == self.judgementCounter then
 		return

--- a/sphere/views/ResultView/ResultViewConfig.lua
+++ b/sphere/views/ResultView/ResultViewConfig.lua
@@ -298,7 +298,7 @@ local function Judgements(self)
 	local notes = perfect + notPerfect + miss
 
 	if show then -- LR2 mash can be higher than total count of notes
-		for _, counter in ipairs(judge.counters) do
+		for _, counter in pairs(judge.counters) do
 			notes = notes + counter
 		end
 	end

--- a/sphere/views/ResultView/ResultViewConfig.lua
+++ b/sphere/views/ResultView/ResultViewConfig.lua
@@ -92,13 +92,13 @@ end
 local _ComboGraph = PointGraphView({
 	draw = drawGraph,
 	radius = 2,
-	backgroundColor = {0, 0, 0, 0.2},
+	backgroundColor = { 0, 0, 0, 0.2 },
 	backgroundRadius = 4,
 	point = function(self, point)
 		local y = 1 - point.base.combo / point.base.notesCount
 		return y, 1, 1, 0.25, 1
 	end,
-	show = showLoadedScore
+	show = showLoadedScore,
 })
 
 ---@param self table
@@ -110,7 +110,7 @@ end
 local _EarlyHitGraph = PointGraphView({
 	draw = drawGraph,
 	radius = 4,
-	backgroundColor = {1, 1, 1, 1},
+	backgroundColor = { 1, 1, 1, 1 },
 	backgroundRadius = 6,
 	point = function(self, point)
 		if not point.base.isEarlyHit then
@@ -119,7 +119,7 @@ local _EarlyHitGraph = PointGraphView({
 		local y = point.misc.deltaTime / 0.16 / 2 + 0.5
 		return y, 0.4, 0.35, 0.8, 1
 	end,
-	show = showLoadedScore
+	show = showLoadedScore,
 })
 
 ---@param self table
@@ -128,12 +128,12 @@ local function EarlyHitGraph(self)
 	_EarlyHitGraph:draw()
 end
 
-local perfectColor = {1, 1, 1, 1}
-local notPerfectColor = {1, 0.6, 0.4, 1}
+local perfectColor = { 1, 1, 1, 1 }
+local notPerfectColor = { 1, 0.6, 0.4, 1 }
 local _HitGraph = PointGraphView({
 	draw = drawGraph,
 	radius = 2,
-	backgroundColor = {0, 0, 0, 0.2},
+	backgroundColor = { 0, 0, 0, 0.2 },
 	backgroundRadius = 6,
 	point = function(self, point)
 		if point.base.isMiss then
@@ -147,7 +147,7 @@ local _HitGraph = PointGraphView({
 		local y = point.misc.deltaTime / 0.16 / 2 + 0.5
 		return y, unpack(color)
 	end,
-	show = showLoadedScore
+	show = showLoadedScore,
 })
 
 ---@param self table
@@ -159,7 +159,7 @@ end
 local _MissGraph = PointGraphView({
 	draw = drawGraph,
 	radius = 4,
-	backgroundColor = {1, 1, 1, 1},
+	backgroundColor = { 1, 1, 1, 1 },
 	backgroundRadius = 6,
 	point = function(self, point)
 		if not point.base.isMiss then
@@ -168,7 +168,7 @@ local _MissGraph = PointGraphView({
 		local y = point.misc.deltaTime / 0.16 / 2 + 0.5
 		return y, 1, 0.2, 0.2, 1
 	end,
-	show = showLoadedScore
+	show = showLoadedScore,
 })
 
 ---@param self table
@@ -180,7 +180,7 @@ end
 local _HpGraph = PointGraphView({
 	draw = drawGraph,
 	radius = 2,
-	backgroundColor = {0, 0, 0, 0.2},
+	backgroundColor = { 0, 0, 0, 0.2 },
 	backgroundRadius = 4,
 	point = function(self, point)
 		local value = 0
@@ -195,7 +195,7 @@ local _HpGraph = PointGraphView({
 
 		return 1 - value, 0.25, 1, 0.5, 1
 	end,
-	show = showLoadedScore
+	show = showLoadedScore,
 })
 
 ---@param self table
@@ -222,12 +222,15 @@ local function ScoreList(self)
 	love.graphics.setColor(1, 1, 1, 0.8)
 	h = h / ScoreListView.rows
 	local c = math.floor(ScoreListView.rows / 2)
-	love.graphics.polygon("fill",
-		0, h * (c + 0.2) + (72 - h) / 2,
-		h / 2 * 0.6, h * (c + 0.5) + (72 - h) / 2,
-		0, h * (c + 0.8) + (72 - h) / 2
+	love.graphics.polygon(
+		"fill",
+		0,
+		h * (c + 0.2) + (72 - h) / 2,
+		h / 2 * 0.6,
+		h * (c + 0.5) + (72 - h) / 2,
+		0,
+		h * (c + 0.8) + (72 - h) / 2
 	)
-
 
 	w, h = Layout:move("column3row2")
 	love.graphics.translate(w - 16, 0)
@@ -284,7 +287,11 @@ local function Judgements(self)
 
 	local judgeName = self.game.configModel.configs.select.judgements
 	local judge = self.judgements[judgeName]
-	local judgementLists = judge:getOrderedCounterNames()
+
+	local judgementLists = judge.orderedCounters
+	if judge.getOrderedCounterNames then
+		judgementLists = judge:getOrderedCounterNames()
+	end
 	local counters = judge.counters
 
 	local perfect = show and counters.perfect or scoreItem.perfect or 0
@@ -455,16 +462,24 @@ local function NotechartInfo(self)
 
 	TextCellImView(w * (1 - wr), 55, "right", "notes", chartview.notes_count)
 	just.sameline()
-	TextCellImView(w * wr, 55, "right", "duration",
-		length == baseLength and time_util.format(baseLength) or
-		("%s→%s"):format(time_util.format(baseLength), time_util.format(length))
+	TextCellImView(
+		w * wr,
+		55,
+		"right",
+		"duration",
+		length == baseLength and time_util.format(baseLength)
+			or ("%s→%s"):format(time_util.format(baseLength), time_util.format(length))
 	)
 
 	TextCellImView(w * (1 - wr), 55, "right", "level", chartview.level)
 	just.sameline()
-	TextCellImView(w * wr, 55, "right", "bpm",
-		bpm == baseBpm and math.floor(baseBpm + 0.5) or
-		("%d→%d"):format(math.floor(baseBpm + 0.5), math.floor(bpm + 0.5))
+	TextCellImView(
+		w * wr,
+		55,
+		"right",
+		"bpm",
+		bpm == baseBpm and math.floor(baseBpm + 0.5)
+			or ("%d→%d"):format(math.floor(baseBpm + 0.5), math.floor(bpm + 0.5))
 	)
 
 	w, h = Layout:move("title_sub")
@@ -511,8 +526,8 @@ local function NotechartInfo(self)
 	RoundedRectangle("fill", 0, 0, w, 72, 36, false, false, 2)
 	love.graphics.setColor(1, 1, 1, 1)
 
-	local score = not show and scoreItem.score or
-		erfunc.erf(ratingHitTimingWindow / (normalscore.accuracyAdjusted * math.sqrt(2))) * 10000
+	local score = not show and scoreItem.score
+		or erfunc.erf(ratingHitTimingWindow / (normalscore.accuracyAdjusted * math.sqrt(2))) * 10000
 	if score ~= score then
 		score = 0
 	end
@@ -626,10 +641,10 @@ local function NotechartInfo(self)
 	font:setFallbacks(spherefonts.get("Noto Sans", 40))
 	love.graphics.setFont(font)
 
-	local textInputMode = inputMode == baseInputMode and Format.inputMode(baseInputMode) or
-		("%s→%s"):format(Format.inputMode(baseInputMode), Format.inputMode(inputMode))
-	local textDifficulty = difficulty == baseDifficulty and Format.difficulty(baseDifficulty) or
-		("%s→%s"):format(Format.difficulty(baseDifficulty), Format.difficulty(difficulty))
+	local textInputMode = inputMode == baseInputMode and Format.inputMode(baseInputMode)
+		or ("%s→%s"):format(Format.inputMode(baseInputMode), Format.inputMode(inputMode))
+	local textDifficulty = difficulty == baseDifficulty and Format.difficulty(baseDifficulty)
+		or ("%s→%s"):format(Format.difficulty(baseDifficulty), Format.difficulty(difficulty))
 
 	love.graphics.setFont(spherefonts.get("Noto Sans", 24))
 	just.text("input mode")
@@ -649,7 +664,7 @@ local function NotechartInfo(self)
 
 	w, h = Layout:move("graphs_sup_left")
 	love.graphics.setColor(0, 0, 0, 0.8)
-	RoundedRectangle("fill", 0, 0, w, h, {36, h / 2, 36, h / 2}, false, true)
+	RoundedRectangle("fill", 0, 0, w, h, { 36, h / 2, 36, h / 2 }, false, true)
 	love.graphics.setColor(1, 1, 1, 1)
 	love.graphics.translate(22, 0)
 
@@ -716,7 +731,7 @@ local function BottomScreenMenu(self)
 
 	w, h = Layout:move("graphs_sup_right")
 	love.graphics.setColor(0, 0, 0, 0.8)
-	RoundedRectangle("fill", 0, 0, w, h, {h / 2, 36, h / 2, 36}, true, false)
+	RoundedRectangle("fill", 0, 0, w, h, { h / 2, 36, h / 2, 36 }, true, false)
 	love.graphics.setColor(1, 1, 1, 1)
 	love.graphics.translate(55, 0)
 
@@ -729,10 +744,7 @@ local function BottomScreenMenu(self)
 	end
 	if scoreItem and scoreEntry and scoreItem.id == scoreEntry.id and not scoreItem.file then
 		if imgui.TextOnlyButton("submit", "resubmit", 72 * 2, h) then
-			self.game.onlineModel.onlineScoreManager:submit(
-				self.game.selectModel.chartview,
-				scoreItem.replay_hash
-			)
+			self.game.onlineModel.onlineScoreManager:submit(self.game.selectModel.chartview, scoreItem.replay_hash)
 		end
 	end
 	just.row()

--- a/sphere/views/ResultView/ResultViewConfig.lua
+++ b/sphere/views/ResultView/ResultViewConfig.lua
@@ -298,6 +298,7 @@ local function Judgements(self)
 	local notes = perfect + notPerfect + miss
 
 	if show then -- LR2 mash can be higher than total count of notes
+		notes = 0
 		for _, counter in pairs(judge.counters) do
 			notes = notes + counter
 		end

--- a/sphere/views/ResultView/ResultViewConfig.lua
+++ b/sphere/views/ResultView/ResultViewConfig.lua
@@ -294,7 +294,14 @@ local function Judgements(self)
 	local perfect = show and counters.perfect or scoreItem.perfect or 0
 	local notPerfect = show and counters["not perfect"] or scoreItem.not_perfect or 0
 	local miss = show and judge.counters.miss or scoreItem.miss or 0
-	local notes = show and judge.notes or perfect + notPerfect + miss
+
+	local notes = perfect + notPerfect + miss
+
+	if show then -- LR2 mash can be higher than total count of notes
+		for _, counter in ipairs(judge.counters) do
+			notes = notes + counter
+		end
+	end
 
 	love.graphics.setColor(1, 1, 1, 1)
 	love.graphics.setFont(spherefonts.get("Noto Sans", 24))
@@ -336,10 +343,17 @@ local function JudgementSelector(item, w, h)
 
 	local text = name:format(selectorState[name])
 
+	if item.rangeValueAlias then
+		text = name:format(item.rangeValueAlias[v])
+	end
+
 	local ret
 	just.row(true)
 	if imgui.TextOnlyButton(name .. "judgement", text, w - h * 2, h, "center") then
 		ret = text
+		if item.rangeValueAlias then
+			ret = name:format(item.rangeValueAlias[v])
+		end
 	end
 	if imgui.TextOnlyButton(name .. "judgement<", "<", h, h, "center") and v > item.range[1] then
 		selectorState[name] = v - 1

--- a/sphere/views/ResultView/ResultViewConfig.lua
+++ b/sphere/views/ResultView/ResultViewConfig.lua
@@ -289,9 +289,6 @@ local function Judgements(self)
 	local judge = self.judgements[judgeName]
 
 	local judgementLists = judge.orderedCounters
-	if judge.getOrderedCounterNames then
-		judgementLists = judge:getOrderedCounterNames()
-	end
 	local counters = judge.counters
 
 	local perfect = show and counters.perfect or scoreItem.perfect or 0

--- a/sphere/views/ResultView/init.lua
+++ b/sphere/views/ResultView/init.lua
@@ -40,7 +40,8 @@ function ResultView:updateJudgements()
 		scoreSystems["soundsphere"].metadata,
 		scoreSystems["quaver"].metadata,
 		scoreSystems["osuMania"].metadata,
-		scoreSystems["etterna"].metadata
+		scoreSystems["osuLegacy"].metadata,
+		scoreSystems["etterna"].metadata,
 	}
 
 	self.judgements = {}
@@ -60,10 +61,14 @@ function ResultView:draw()
 	just.container("screen container", true)
 
 	local kp = just.keypressed
-	if kp("up") then self.game.selectModel:scrollScore(-1)
-	elseif kp("down") then self.game.selectModel:scrollScore(1)
-	elseif kp("escape") then self:quit()
-	elseif kp("return") then self:loadScore()
+	if kp("up") then
+		self.game.selectModel:scrollScore(-1)
+	elseif kp("down") then
+		self.game.selectModel:scrollScore(1)
+	elseif kp("escape") then
+		self:quit()
+	elseif kp("return") then
+		self:loadScore()
 	end
 
 	Layout:draw()

--- a/sphere/views/ResultView/init.lua
+++ b/sphere/views/ResultView/init.lua
@@ -42,6 +42,7 @@ function ResultView:updateJudgements()
 		scoreSystems["osuMania"].metadata,
 		scoreSystems["osuLegacy"].metadata,
 		scoreSystems["etterna"].metadata,
+		scoreSystems["lr2"].metadata,
 	}
 
 	self.judgements = {}

--- a/sphere/views/TimingsModalView.lua
+++ b/sphere/views/TimingsModalView.lua
@@ -7,7 +7,7 @@ local table_util = require("table_util")
 
 local _timings = require("sphere.models.RhythmModel.ScoreEngine.timings")
 
-local transform = {{1 / 2, -16 / 9 / 2}, 0, 0, {0, 1 / 1080}, {0, 1 / 1080}, 0, 0, 0, 0}
+local transform = { { 1 / 2, -16 / 9 / 2 }, 0, 0, { 0, 1 / 1080 }, { 0, 1 / 1080 }, 0, 0, 0, 0 }
 
 ---@param id any
 ---@param v number
@@ -18,14 +18,26 @@ local function intButtons(id, v, w, h)
 	local _v = v
 	local mod = love.keyboard.isScancodeDown("lshift", "rshift")
 	if not mod then
-		if imgui.TextButton(id .. "-1", "-1", w / 4, h) then v = v - 1 end
-		if imgui.TextButton(id .. "+1", "+1", w / 4, h) then v = v + 1 end
+		if imgui.TextButton(id .. "-1", "-1", w / 4, h) then
+			v = v - 1
+		end
+		if imgui.TextButton(id .. "+1", "+1", w / 4, h) then
+			v = v + 1
+		end
 	end
-	if imgui.TextButton(id .. "-10", "-10", w / 4, h) then v = v - 10 end
-	if imgui.TextButton(id .. "+10", "+10", w / 4, h) then v = v + 10 end
+	if imgui.TextButton(id .. "-10", "-10", w / 4, h) then
+		v = v - 10
+	end
+	if imgui.TextButton(id .. "+10", "+10", w / 4, h) then
+		v = v + 10
+	end
 	if mod then
-		if imgui.TextButton(id .. "-100", "-100", w / 4, h) then v = v - 100 end
-		if imgui.TextButton(id .. "+100", "+100", w / 4, h) then v = v + 100 end
+		if imgui.TextButton(id .. "-100", "-100", w / 4, h) then
+			v = v - 100
+		end
+		if imgui.TextButton(id .. "+100", "+100", w / 4, h) then
+			v = v + 100
+		end
 	end
 	if v ~= _v then
 		return math.floor(v)
@@ -104,15 +116,14 @@ return ModalImView(function(self, quit)
 	if imgui.TextButton("lr2 timings", "LR2", 100, _h2) then
 		playContext.timings = table_util.deepcopy(_timings.lr2)
 	end
-	if imgui.TextButton("osu timings", "osu OD" .. osuOD, 150, _h2) then
+	if imgui.TextButton("osu timings", "osu!mania OD" .. osuOD, 220, _h2) then
 		playContext.timings = table_util.deepcopy(_timings.osu(osuOD))
 		osuOD = (osuOD + 1) % 11
 	end
-	if imgui.TextButton("etterna timings", "J" .. etternaJudgement, 150, _h2) then
-		playContext.timings = table_util.deepcopy(_timings.etterna(etternaJudgement))
-		etternaJudgement = etternaJudgement % 9 + 1
+	if imgui.TextButton("etterna timings", "Etterna", 150, _h2) then
+		playContext.timings = table_util.deepcopy(_timings.etterna)
 	end
-	if imgui.TextButton("quaver timings", "quaver", 150, _h2) then
+	if imgui.TextButton("quaver timings", "Quaver", 150, _h2) then
 		playContext.timings = table_util.deepcopy(_timings.quaver)
 	end
 	just.row()

--- a/sphere/views/TimingsModalView.lua
+++ b/sphere/views/TimingsModalView.lua
@@ -75,6 +75,7 @@ local function drawTimings(t, name, id, norm, mins, w, h)
 end
 
 local osuOD = 0
+local osuLegacyOD = 0
 local etternaJudgement = 1
 
 return ModalImView(function(self, quit)
@@ -116,9 +117,13 @@ return ModalImView(function(self, quit)
 	if imgui.TextButton("lr2 timings", "LR2", 100, _h2) then
 		playContext.timings = table_util.deepcopy(_timings.lr2)
 	end
-	if imgui.TextButton("osu timings", "osu!mania OD" .. osuOD, 220, _h2) then
-		playContext.timings = table_util.deepcopy(_timings.osu(osuOD))
+	if imgui.TextButton("osuMania timings", "osu!mania OD" .. osuOD, 220, _h2) then
+		playContext.timings = table_util.deepcopy(_timings.osuMania(osuOD))
 		osuOD = (osuOD + 1) % 11
+	end
+	if imgui.TextButton("osuLegacy timings", "osu!legacy OD" .. osuLegacyOD, 220, _h2) then
+		playContext.timings = table_util.deepcopy(_timings.osuLegacy(osuLegacyOD))
+		osuLegacyOD = (osuLegacyOD + 1) % 11
 	end
 	if imgui.TextButton("etterna timings", "Etterna", 150, _h2) then
 		playContext.timings = table_util.deepcopy(_timings.etterna)


### PR DESCRIPTION
Added:
- osu!legacy - scoring from osu!mania stable. This includes score for calculating PP
- Lunatic rave 2 scoring
- Base judge class

Changed:
- Fixed timing windows of osu!mania scoring. You now can't get late 'meh'. And hit window became shorter.
- Easier access to judges. Get the ScoreSystemContainer and there you have `judgements` field with all the judgements from all score systems
- Judge selector in the result screen now can show strings if the score system metadata has 'rangeValueAlias'
- Each judge now has it's own orderedCounter field, removed getOrderedCountNames from the score systems
- Soundsphere score system is now named soundsphere
