### PR TITLE
Use correct names for scoring system judgements

### DIFF
--- a/sphere/models/RhythmModel/ScoreEngine/EtternaScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/EtternaScoring.lua
@@ -42,6 +42,7 @@ Judge.orderedCounters = { "marvelous", "perfect", "great", "bad", "boo" }
 ---@param j number
 function Judge:new(j)
 	BaseJudge.new(self)
+	self.judgeName = EtternaScoring.metadata.name:format(j)
 	self.scoreSystemName = EtternaScoring.name
 
 	self.difficulty = judgeDifficulty[j]

--- a/sphere/models/RhythmModel/ScoreEngine/OsuLegacyScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/OsuLegacyScoring.lua
@@ -67,7 +67,7 @@ local hitBonusValue = {
 ---@param od number
 function Judge:new(od)
 	BaseJudge.new(self)
-	self.judgeName = OsuLegacyScoring.name:format(od)
+	self.judgeName = OsuLegacyScoring.metadata.name:format(od)
 	self.scoreSystemName = OsuLegacyScoring.name
 
 	self.weights = {

--- a/sphere/models/RhythmModel/ScoreEngine/OsuManiaScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/OsuManiaScoring.lua
@@ -26,7 +26,7 @@ Judge.orderedCounters = { "perfect", "great", "good", "ok", "meh" }
 ---@param od number
 function Judge:new(od)
 	BaseJudge.new(self)
-	self.judgeName = OsuManiaScoring.name:format(od)
+	self.judgeName = OsuManiaScoring.metadata.name:format(od)
 	self.scoreSystemName = OsuManiaScoring.name
 
 	self.weights = {

--- a/sphere/models/RhythmModel/ScoreEngine/QuaverScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/QuaverScoring.lua
@@ -25,6 +25,7 @@ Judge.orderedCounters = { "marvelous", "perfect", "great", "good", "okay" }
 ---@param windows table
 function Judge:new(windows)
 	BaseJudge.new(self)
+	self.judgeName = QuaverScoring.metadata.name
 	self.scoreSystemName = QuaverScoring.name
 
 	self.windows = windows

--- a/sphere/models/RhythmModel/ScoreEngine/SoundsphereScoring.lua
+++ b/sphere/models/RhythmModel/ScoreEngine/SoundsphereScoring.lua
@@ -20,6 +20,7 @@ Judge.orderedCounters = { "perfect", "not perfect" }
 
 function Judge:new()
 	BaseJudge.new(self)
+	self.judgeName = SoundsphereScoring.metadata.name
 	self.scoreSystemName = SoundsphereScoring.name
 	self.accuracy = nil
 


### PR DESCRIPTION
Judgments used the name of the scoring system, such as osuLegacy, instead of osu!legacy OD8